### PR TITLE
works when device name has 2 digits at the end

### DIFF
--- a/rpi-backup.sh
+++ b/rpi-backup.sh
@@ -43,7 +43,7 @@ sudo parted $img --script -- mkpart primary ext4 ${rootstart}s -1
 
 echo =====================  part 3, mount img to system  ===============================
 loopdevice=`sudo losetup -f --show $img`
-device=/dev/mapper/`sudo kpartx -va $loopdevice | sed -E 's/.*(loop[0-9])p.*/\1/g' | head -1`
+device=/dev/mapper/`sudo kpartx -va $loopdevice | sed -E 's/.*(loop[0-9]+)p.*/\1/g' | head -1`
 sleep 5
 sudo mkfs.vfat ${device}p1 -n boot
 sudo mkfs.ext4 ${device}p2 -L rootfs


### PR DESCRIPTION
In part3, if there are two digits in the end of the device path ,e.g. /dev/mapper/loop15p1 and /dev/mapper/loop15p2
sed -E 's/.*(loop[0-9])p.*/\1/g' would not work normally.
while
sed -E 's/.*(loop[0-9]+)p.*/\1/g' would work normally.